### PR TITLE
Ajuste no indicador de paginação nos arquivos pdf

### DIFF
--- a/src/Boleto/Render/AbstractPdf.php
+++ b/src/Boleto/Render/AbstractPdf.php
@@ -19,7 +19,7 @@ abstract class AbstractPdf extends \FPDF
 
     public function Footer()
     {
-        $this->SetY(-20);
+        $this->SetY(-8);
         if (count($this->PageGroups)) {
             $this->Cell(0, 6, 'Boleto '.$this->GroupPageNo().'/'.$this->PageGroupAlias(), 0, 0, 'C');
         }


### PR DESCRIPTION
Nos arquivos PDF dos boletos o indicador de páginas estava sendo sobreposto pelo código de barras.
Fiz um pequeno ajuste colocando a posição do indicador de páginas ligeiramente abaixo do código de barras, como deve ser. 